### PR TITLE
Move people no longer involved in standards under a new subheading

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ Please sign this document to certify you've read and commit to it. (Sign by push
 - Stu Heiss
 - Jordan Welch
 - Matt Holmes
-- Shad Mickelberry
 - Jorge Carrillo
-- Giovanni Perez
 - Brad Zasada
 - Daniel Lind
+
+### Past stewards
+- Shad Mickelberry
+- Giovanni Perez
 - Kristina Giffin
 - Chris Womble
 - Greg Ochab


### PR DESCRIPTION
This isn't a proposal, just moving signatures of those no longer involved in standards creation for accuracy/clarity.