### PR TITLE
Add note for avoiding naming conflicts

### DIFF
--- a/standards/README.md
+++ b/standards/README.md
@@ -26,7 +26,7 @@ Proposals must include:
 
 #### Amendment
 1. Check that no one else has begun working on the same amendment by checking open branches and/or asking the other devs.
-2. Branch off of `main`. Name the branch after the [filepath](#directory-structure) using kebab-case, prefixed with `amendment-` (e.g. `amendment-practices-linting`).
+2. Branch off of `main`. Name the branch after the [filepath](#directory-structure) using kebab-case, prefixed with `amendment-` (e.g. `amendment-practices-linting`). If this would result in a branch naming conflict, append a unique identifier to the end of the branch name (e.g. `amendment-practices-linting-php-cs-fixer`).
 3. Push the empty branch immediately for visibility and to help prevent duplicate efforts.
 4. Draft your changes.
 5. Create a pull request with a descriptive title.


### PR DESCRIPTION
## Author checklist
- [x] I'm proposing a single change in this PR.
- I believe the proposed standard:
  - [x] benefits more than it costs us and
  - [x] doesn't conflict with our people-first value.
- [x] The standard's file(s) follow(s) [the established directory structure][directory-structure].
- I provided:
  - [x] a succinct summary,
  - [x] reasoning for the proposed change,
  - [x] an example/instructions on how to embody the standard unless repealing, and
  - [x] a longer explanation if appropriate.

*Check boxes if requirement met or irrelevant.*


## First reviewer checklist
***NOTE:** Some of the author's checklist items are intentionally omitted, because they are a matter of opinion and up for discussion with the whole team.*

- [ ] This PR contains a single change.
- [ ] The proposed standard follows [the established directory structure][directory-structure].
- The author provided:
  - [ ] a succinct summary,
  - [ ] reasoning for the proposed change, and
  - [ ] an example/instructions on how to embody the standard unless repealing.

*Check boxes if requirement met or irrelevant.*

---

# Summary
This amendment is just to avoid branch naming conflicts when there are multiple proposed amendments to the same standard.

#18 is an example of why this is necessary.


[directory-structure]: ../tree/main/standards#directory-structure
