### PR TITLE
Maintaining standard Draft 1

### DIFF
--- a/standards/practices/maintaining.md
+++ b/standards/practices/maintaining.md
@@ -1,0 +1,24 @@
+# Maintaining
+
+## Summary
+We maintain our code and keep it updated whenever Highland is working on it.
+
+## Reasoning
+1. Over time it becomes harder and harder to work with code that is reliant on outdated language and framework versions.
+2. Keeping our software projects up to date mitigates the need to constantly be changing language and framework versions in development environments while moving between projects.
+3. The longer updates go unaddressed, the harder they become to make.
+4. Client's will almost never make code maintenance a priority, so we must. 
+
+## Example/Instructions
+
+### PHP & Laravel
+* We use [Laravel Shift](https://laravelshift.com/) to assist in Laravel updates. 
+  * Shift works by automatically updating Laravel and creating a PR with explanations and notes of any steps the developer may have to take.
+  * Check out that branch, run the test suite, and review the app to make sure there are no problems.
+  * Approve and merge the PR. 
+* [Updating to PHP 8.0 with Laravel](https://blog.laravel.com/laravel-php-8-support)
+
+## Exceptions
+* We understand that this is sometimes not practical for legacy projects or ones that rely on brittle integrations.
+* We strive to not create projects like this, but we understand it can happen.
+* Developer discretion should take all factors into account before attempting updates.


### PR DESCRIPTION
Jordan's old PR (#14) can't be reopened since it's set to merge into `master` and we deleted that branch when we switched to using `main`.

I'm checking all the boxes here to match where we left off, but there's still feedback in there that needs to be addressed. @ashabrah seemed like he may be interested in taking over the effort to get this ready for a vote. Is that accurate, Ashish?

## Author checklist
- [x] I'm proposing a single change in this PR.
- I believe the proposed standard:
  - [x] benefits more than it costs us and
  - [x] doesn't conflict with our people-first value.
- [x] The standard's file(s) follow(s) [the established directory structure][directory-structure].
- I provided:
  - [x] a succinct summary,
  - [x] reasoning for the proposed change,
  - [x] an example/instructions on how to embody the standard unless repealing, and
  - [x] a longer explanation if appropriate.

*Check boxes if requirement met or irrelevant.*


## First reviewer checklist
***NOTE:** Some of the author's checklist items are intentionally omitted, because they are a matter of opinion and up for discussion with the whole team.*

- [x] This PR contains a single change.
- [x] The proposed standard follows [the established directory structure][directory-structure].
- The author provided:
  - [x] a succinct summary,
  - [x] reasoning for the proposed change, and
  - [x] an example/instructions on how to embody the standard unless repealing.

*Check boxes if requirement met or irrelevant.*




[directory-structure]: ../tree/main/standards#directory-structure
